### PR TITLE
N 시간 후 예상 시각 표시 기능 추가

### DIFF
--- a/lib/screen/settings_screen.dart
+++ b/lib/screen/settings_screen.dart
@@ -12,6 +12,7 @@ class SettingsScreen extends StatefulWidget {
   final Duration showAverage;
   final AudioPlayer audioPlayer;
   final bool showMeso;
+  final bool showExpectedTime;
 
   const SettingsScreen({
     Key? key,
@@ -21,6 +22,7 @@ class SettingsScreen extends StatefulWidget {
     required this.showAverage,
     required this.audioPlayer,
     required this.showMeso,
+    required this.showExpectedTime,
   }) : super(key: key);
 
   @override
@@ -34,6 +36,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WindowListener {
   double currentVolume = 0.5;
   late AudioPlayer _audioPlayer;
   bool showMeso = false;
+  bool showExpectedTime = true;
 
   @override
   void initState() {
@@ -44,8 +47,9 @@ class _SettingsScreenState extends State<SettingsScreen> with WindowListener {
     _audioPlayer = widget.audioPlayer;
     currentVolume = _audioPlayer.volume;
     showMeso = widget.showMeso;
+    showExpectedTime = widget.showExpectedTime;
 
-    windowManager.setSize(Size(appSize.width, 260));
+    windowManager.setSize(Size(appSize.width, 300));
 
     super.initState();
   }
@@ -122,6 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WindowListener {
       'timerEndTime': selectedDuration1,
       'showAverage': selectedDuration2,
       'showMeso': showMeso,
+      'showExpectedTime': showExpectedTime,
     });
   }
 
@@ -271,6 +276,33 @@ class _SettingsScreenState extends State<SettingsScreen> with WindowListener {
                           _selectedOption2 = value;
                         });
                       },
+                    ),
+                    const SizedBox(height: 4),
+                    // Add this new section
+                    Row(
+                      children: [
+                        Text(
+                          "N 시간 후 예상 시각 표시",
+                          style: GoogleFonts.notoSans(
+                            textStyle: const TextStyle(
+                              color: CupertinoColors.systemGrey6,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Transform.scale(
+                          scale: 0.8,
+                          child: CupertinoSwitch(
+                            value: showExpectedTime,
+                            onChanged: (bool value) {
+                              setState(() {
+                                showExpectedTime = value;
+                              });
+                            },
+                          ),
+                        ),
+                      ],
                     ),
                     Expanded(child: Container()),
                   ],


### PR DESCRIPTION
파티 사냥할 때, "저희 몇시 종료죠?" 같은 질문이 많이 들어오는데, 타이머에 종료 예정 시각을 표시해주면 좋겠다고 생각이 되어 기능을 추가하게 되었습니다. Flutter는 처음 작업해봐서 코드 질이 좋지 않을 수 있습니다.

![image](https://github.com/user-attachments/assets/738c9aa2-5b8e-4f7a-8427-69d9fbd3732d)
![image](https://github.com/user-attachments/assets/d6f4966a-465b-4171-afea-d14d0bd73798)
![image](https://github.com/user-attachments/assets/f974e749-3611-463d-9c86-6d171bfe1003)