### PR TITLE
설정창에서 예상 시각 표시 switch의 색상을 일관성을 위해 초록색에서 파란색으로 변경

### DIFF
--- a/lib/screen/settings_screen.dart
+++ b/lib/screen/settings_screen.dart
@@ -295,6 +295,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WindowListener {
                           scale: 0.8,
                           child: CupertinoSwitch(
                             value: showExpectedTime,
+                            activeTrackColor: CupertinoColors.systemBlue,
                             onChanged: (bool value) {
                               setState(() {
                                 showExpectedTime = value;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/afd165c5-edad-477f-bdb0-c14a7917237e)
